### PR TITLE
Fix Invalid Community Edition license error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG IMAGE=intersystemsdc/iris-community:2019.4.0.383.0-zpm
 ARG IMAGE=intersystemsdc/iris-community:2020.1.0.209.0-zpm
 ARG IMAGE=intersystemsdc/iris-community:2020.2.0.196.0-zpm
 ARG IMAGE=intersystemsdc/iris-community:2020.3.0.200.0-zpm
+#Replaced with below image to fix Error: Invalid Community Edition license
+ARG IMAGE=intersystemsdc/iris-community:2021.1.0.215.3-zpm
 FROM $IMAGE
 
 


### PR DESCRIPTION
#Replaced with below image to fix Error: Invalid Community Edition license
ARG IMAGE=intersystemsdc/iris-community:2021.1.0.215.3-zpm
FROM $IMAGE