### PR TITLE
Installer.cls : rename class to App.Installer

### DIFF
--- a/Installer.cls
+++ b/Installer.cls
@@ -1,5 +1,5 @@
 /// an example of Installer class just to create a new clear namespace and database IRISAPP
-Class Installer
+Class App.Installer
 {
 
 XData setup


### PR DESCRIPTION
Install failed to create as the class was not correctly named App.Installer